### PR TITLE
Investigate zero cogs when hpos disabled

### DIFF
--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -562,6 +562,14 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @return float|null The calculated value, null if the product associated to the line item no longer exists.
 	 */
 	public function calculate_cogs_value_core(): ?float {
+		// If this item already has a saved COGS value, return it.
+		// COGS should be "snapshotted" at order creation time, not recalculated from current product values.
+		$existing_value = $this->get_cogs_value( 'edit' );
+		if ( $existing_value > 0 ) {
+			return $existing_value;
+		}
+
+		// Otherwise, calculate from the product.
 		$product = $this->get_product();
 		if ( ! $product ) {
 			return null;

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -562,15 +562,19 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @return float|null The calculated value, null if the product associated to the line item no longer exists.
 	 */
 	public function calculate_cogs_value_core(): ?float {
-		// If this item has been loaded from the database and has a saved COGS value, preserve it.
+		// Refund items should always recalculate based on their (negative) quantity.
+		// Preserving would give incorrect values since they're cloned from original items.
+		$is_refund_item = $this->get_quantity() < 0;
+
+		// If this is a regular item (not refund) that has been loaded from the database and has a saved COGS value, preserve it.
 		// COGS values should be "snapshotted" at order creation time, not recalculated later.
 		// This prevents historical orders from having their costs changed when product prices are updated.
 		// Note: cogs_value will be null if the item was loaded but had no _cogs_value metadata.
-		if ( $this->get_id() > 0 && $this->get_object_read() && isset( $this->data['cogs_value'] ) && ! is_null( $this->data['cogs_value'] ) ) {
+		if ( ! $is_refund_item && $this->get_id() > 0 && $this->get_object_read() && isset( $this->data['cogs_value'] ) && ! is_null( $this->data['cogs_value'] ) ) {
 			return $this->get_cogs_value( 'edit' );
 		}
 
-		// For new items or items without saved COGS, calculate from the product.
+		// For new items, refund items, or items without saved COGS, calculate from the product.
 		$product = $this->get_product();
 		if ( ! $product ) {
 			return null;

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -562,14 +562,15 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @return float|null The calculated value, null if the product associated to the line item no longer exists.
 	 */
 	public function calculate_cogs_value_core(): ?float {
-		// If this item already has a saved COGS value, return it.
-		// COGS should be "snapshotted" at order creation time, not recalculated from current product values.
-		$existing_value = $this->get_cogs_value( 'edit' );
-		if ( $existing_value > 0 ) {
-			return $existing_value;
+		// If this item has been loaded from the database and has a saved COGS value, preserve it.
+		// COGS values should be "snapshotted" at order creation time, not recalculated later.
+		// This prevents historical orders from having their costs changed when product prices are updated.
+		// Note: cogs_value will be null if the item was loaded but had no _cogs_value metadata.
+		if ( $this->get_id() > 0 && $this->get_object_read() && isset( $this->data['cogs_value'] ) && ! is_null( $this->data['cogs_value'] ) ) {
+			return $this->get_cogs_value( 'edit' );
 		}
 
-		// Otherwise, calculate from the product.
+		// For new items or items without saved COGS, calculate from the product.
 		$product = $this->get_product();
 		if ( ! $product ) {
 			return null;

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -814,6 +814,30 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		$this->update_post_meta( $order );
+
+		// Sync COGS value during backfill if needed (for compatibility mode).
+		if ( $order->has_cogs() && method_exists( $this, 'cogs_is_enabled' ) && $this->cogs_is_enabled() ) {
+			$cogs_value = $order->get_cogs_total_value( 'edit' );
+
+			/**
+			 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
+			 * or to suppress the saving of the value (so that custom storage can be used).
+			 *
+			 * @since 9.5.0
+			 *
+			 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
+			 * @param WC_Abstract_Order $item The order for which the value is being saved.
+			 */
+			$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
+
+			if ( ! is_null( $cogs_value ) ) {
+				if ( 0.0 === (float) $cogs_value ) {
+					delete_post_meta( $order->get_id(), '_cogs_total_value' );
+				} else {
+					update_post_meta( $order->get_id(), '_cogs_total_value', $cogs_value );
+				}
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -814,30 +814,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		}
 
 		$this->update_post_meta( $order );
-
-		// Sync COGS value during backfill if needed (for compatibility mode).
-		if ( $order->has_cogs() && method_exists( $this, 'cogs_is_enabled' ) && $this->cogs_is_enabled() ) {
-			$cogs_value = $order->get_cogs_total_value( 'edit' );
-
-			/**
-			 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
-			 * or to suppress the saving of the value (so that custom storage can be used).
-			 *
-			 * @since 9.5.0
-			 *
-			 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
-			 * @param WC_Abstract_Order $item The order for which the value is being saved.
-			 */
-			$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
-
-			if ( ! is_null( $cogs_value ) ) {
-				if ( 0.0 === (float) $cogs_value ) {
-					delete_post_meta( $order->get_id(), '_cogs_total_value' );
-				} else {
-					update_post_meta( $order->get_id(), '_cogs_total_value', $cogs_value );
-				}
-			}
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -179,19 +179,25 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		$item->read_meta_data();
 
 		if ( $this->cogs_is_enabled && $item->has_cogs() ) {
-			$cogs_value = (float) $this->order_item_data_store->get_metadata( $item->get_id(), '_cogs_value', true );
+			$cogs_metadata = $this->order_item_data_store->get_metadata( $item->get_id(), '_cogs_value', true );
+			
+			// Only set COGS value if the metadata actually exists.
+			// If it doesn't exist, leave it as null so it can be calculated later.
+			if ( '' !== $cogs_metadata && false !== $cogs_metadata ) {
+				$cogs_value = (float) $cogs_metadata;
 
-			/**
-			 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order item.
-			 *
-			 * @since 9.5.0
-			 *
-			 * @param float $cogs_value The value as read from the database.
-			 * @param WC_Order_Item $product The order item for which the value is being loaded.
-			 */
-			$cogs_value = apply_filters( 'woocommerce_load_order_item_cogs_value', $cogs_value, $item );
+				/**
+				 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order item.
+				 *
+				 * @since 9.5.0
+				 *
+				 * @param float $cogs_value The value as read from the database.
+				 * @param WC_Order_Item $product The order item for which the value is being loaded.
+				 */
+				$cogs_value = apply_filters( 'woocommerce_load_order_item_cogs_value', $cogs_value, $item );
 
-			$item->set_cogs_value( (float) $cogs_value );
+				$item->set_cogs_value( (float) $cogs_value );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -271,6 +271,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			'_recorded_coupon_usage_counts' => 'recorded_coupon_usage_counts',
 			'_new_order_email_sent'         => 'new_order_email_sent',
 			'_order_stock_reduced'          => 'order_stock_reduced',
+			'_cogs_total_value'             => 'cogs_total_value',
 		);
 
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
@@ -298,6 +299,23 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					}
 					$value = is_bool( $value ) ? wc_bool_to_string( $value ) : $value;
 					$value = 'yes' === $value ? 'true' : 'false'; // For backward compatibility, we store as true/false in DB.
+					break;
+				case 'cogs_total_value':
+					// Skip COGS if feature is disabled or order doesn't manage COGS.
+					if ( ! $order->has_cogs() || ! $this->cogs_is_enabled() ) {
+						continue 2; // Skip to next iteration of foreach.
+					}
+					// Apply the save filter.
+					$value = apply_filters( 'woocommerce_save_order_cogs_value', $value, $order );
+					if ( is_null( $value ) ) {
+						continue 2; // Filter returned null, skip saving.
+					}
+					// Delete meta if value is zero (optimization).
+					if ( 0.0 === (float) $value ) {
+						delete_post_meta( $id, $meta_key );
+						$updated_props[] = $prop;
+						continue 2;
+					}
 					break;
 			}
 
@@ -356,11 +374,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		}
 
 		parent::update_post_meta( $order );
-
-		// Save Cost of Goods Sold data if the feature is enabled and the order manages COGS.
-		if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
-			$this->save_cogs_data( $order );
-		}
 
 		// If address changed, store concatenated version to make searches faster.
 		if ( in_array( 'billing', $updated_props, true ) || ! metadata_exists( 'post', $id, '_billing_address_index' ) ) {
@@ -1422,37 +1435,5 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		$order->set_cogs_total_value( (float) $cogs_value );
 		$order->apply_changes();
-	}
-
-	/**
-	 * Save the Cost of Goods Sold value of a given order to the database.
-	 *
-	 * @param WC_Order $order The order to save the COGS value for.
-	 */
-	private function save_cogs_data( $order ) {
-		$cogs_value = $order->get_cogs_total_value();
-
-		/**
-		 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
-		 * or to suppress the saving of the value (so that custom storage can be used).
-		 *
-		 * @since 9.5.0
-		 *
-		 * @param float|null         $cogs_value The value to be written to the database. If returned as null, nothing will be written.
-		 * @param WC_Abstract_Order $order      The order for which the value is being saved.
-		 */
-		$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
-		if ( is_null( $cogs_value ) ) {
-			return;
-		}
-
-		$order_id = $order->get_id();
-
-		// Delete the meta if the value is zero, otherwise update it.
-		if ( 0.0 === $cogs_value ) {
-			delete_post_meta( $order_id, '_cogs_total_value' );
-		} else {
-			update_post_meta( $order_id, '_cogs_total_value', $cogs_value );
-		}
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1417,7 +1417,12 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		parent::update_order_meta_from_object( $order );
 
 		// Sync COGS value during backfill if needed (for compatibility mode).
-		if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
+		// Check if COGS is enabled first to avoid triggering "doing it wrong" notices.
+		if ( ! $this->cogs_is_enabled() ) {
+			return;
+		}
+
+		if ( $order->has_cogs() ) {
 			$cogs_value = $order->get_cogs_total_value( 'edit' );
 
 			/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version  3.0.0
  */
 class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implements WC_Object_Data_Store_Interface, WC_Order_Data_Store_Interface {
+	use CogsAwareTrait;
 
 	/**
 	 * Data stored in meta keys, but not considered "meta" for an order.
@@ -80,6 +82,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		'_download_permissions_granted',
 		'_order_stock_reduced',
 		'_new_order_email_sent',
+		'_cogs_total_value',
 	);
 
 	/**
@@ -182,6 +185,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'recorded_coupon_usage_counts' => $post_meta['_recorded_coupon_usage_counts'][0] ?? '',
 			)
 		);
+
+		// Load Cost of Goods Sold data if the feature is enabled and the order manages COGS.
+		if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
+			$this->read_cogs_data( $order, $post_meta );
+		}
 	}
 
 	/**
@@ -348,6 +356,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		}
 
 		parent::update_post_meta( $order );
+
+		// Save Cost of Goods Sold data if the feature is enabled and the order manages COGS.
+		if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
+			$this->save_cogs_data( $order );
+		}
 
 		// If address changed, store concatenated version to make searches faster.
 		if ( in_array( 'billing', $updated_props, true ) || ! metadata_exists( 'post', $id, '_billing_address_index' ) ) {
@@ -1386,5 +1399,60 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			'compare' => $operator,
 			'type'    => '=' === $operator ? 'CHAR' : 'DECIMAL(10,' . wc_get_price_decimals() . ')',
 		);
+	}
+
+	/**
+	 * Read the Cost of Goods Sold value for a given order from the database, if available, and apply it to the order.
+	 *
+	 * @param WC_Order $order The order to get the COGS value for.
+	 * @param array    $post_meta The post meta data array.
+	 */
+	private function read_cogs_data( $order, $post_meta ) {
+		$cogs_value = isset( $post_meta['_cogs_total_value'][0] ) ? (float) $post_meta['_cogs_total_value'][0] : 0;
+
+		/**
+		 * Filter to customize the Cost of Goods Sold value that gets loaded for a given order.
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param float              $cogs_value The value as read from the database.
+		 * @param WC_Abstract_Order $order      The order for which the value is being loaded.
+		 */
+		$cogs_value = apply_filters( 'woocommerce_load_order_cogs_value', $cogs_value, $order );
+
+		$order->set_cogs_total_value( (float) $cogs_value );
+		$order->apply_changes();
+	}
+
+	/**
+	 * Save the Cost of Goods Sold value of a given order to the database.
+	 *
+	 * @param WC_Order $order The order to save the COGS value for.
+	 */
+	private function save_cogs_data( $order ) {
+		$cogs_value = $order->get_cogs_total_value();
+
+		/**
+		 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
+		 * or to suppress the saving of the value (so that custom storage can be used).
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param float|null         $cogs_value The value to be written to the database. If returned as null, nothing will be written.
+		 * @param WC_Abstract_Order $order      The order for which the value is being saved.
+		 */
+		$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
+		if ( is_null( $cogs_value ) ) {
+			return;
+		}
+
+		$order_id = $order->get_id();
+
+		// Delete the meta if the value is zero, otherwise update it.
+		if ( 0.0 === $cogs_value ) {
+			delete_post_meta( $order_id, '_cogs_total_value' );
+		} else {
+			update_post_meta( $order_id, '_cogs_total_value', $cogs_value );
+		}
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -277,14 +277,22 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
-			// Skip COGS property if feature is disabled to avoid triggering "doing it wrong" notices.
-			if ( 'cogs_total_value' === $prop && ! $this->cogs_is_enabled() ) {
-				continue;
+			// Handle COGS property specially to avoid triggering "doing it wrong" notices when disabled.
+			if ( 'cogs_total_value' === $prop ) {
+				if ( ! $this->cogs_is_enabled() ) {
+					continue; // Skip if COGS is disabled.
+				}
+				$value = $order->get_cogs_total_value( 'edit' );
+				if ( $this->handle_cogs_value_update( $order, $value, $id, $meta_key, $updated_props, $prop ) ) {
+					continue; // Handler processed it, skip standard flow.
+				}
+				// If handler returns false, value is already set, fall through to standard flow below.
+			} else {
+				$value = $order->{"get_$prop"}( 'edit' );
 			}
 
-			$value = $order->{"get_$prop"}( 'edit' );
+			// Value is either already set (for COGS) or retrieved above.
 			$value = is_string( $value ) ? wp_slash( $value ) : $value;
-			$skip_property = false;
 
 			switch ( $prop ) {
 				case 'date_paid':
@@ -307,14 +315,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					$value = is_bool( $value ) ? wc_bool_to_string( $value ) : $value;
 					$value = 'yes' === $value ? 'true' : 'false'; // For backward compatibility, we store as true/false in DB.
 					break;
-				case 'cogs_total_value':
-					$skip_property = $this->handle_cogs_value_update( $order, $value, $id, $meta_key, $updated_props, $prop );
-					break;
-			}
-
-			// Skip to next property if the handler indicated to do so.
-			if ( $skip_property ) {
-				continue;
 			}
 
 			// We want to persist internal data store keys as 'yes' or 'no' if they are boolean to maintain compatibility.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1448,7 +1448,15 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			return true; // Skip this property.
 		}
 
-		// Apply the save filter.
+		/**
+		 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
+		 * or to suppress the saving of the value (so that custom storage can be used).
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
+		 * @param WC_Abstract_Order $item The order for which the value is being saved.
+		 */
 		$value = apply_filters( 'woocommerce_save_order_cogs_value', $value, $order );
 		if ( is_null( $value ) ) {
 			return true; // Filter returned null, skip saving.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1408,6 +1408,40 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
+	 * Helper method to update order metadata from initialized order object.
+	 * Overrides the parent method to add COGS sync support for compatibility mode.
+	 *
+	 * @param WC_Abstract_Order $order Order object.
+	 */
+	protected function update_order_meta_from_object( $order ) {
+		parent::update_order_meta_from_object( $order );
+
+		// Sync COGS value during backfill if needed (for compatibility mode).
+		if ( $order->has_cogs() && $this->cogs_is_enabled() ) {
+			$cogs_value = $order->get_cogs_total_value( 'edit' );
+
+			/**
+			 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
+			 * or to suppress the saving of the value (so that custom storage can be used).
+			 *
+			 * @since 9.5.0
+			 *
+			 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
+			 * @param WC_Abstract_Order $item The order for which the value is being saved.
+			 */
+			$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
+
+			if ( ! is_null( $cogs_value ) ) {
+				if ( 0.0 === (float) $cogs_value ) {
+					delete_post_meta( $order->get_id(), '_cogs_total_value' );
+				} else {
+					update_post_meta( $order->get_id(), '_cogs_total_value', $cogs_value );
+				}
+			}
+		}
+	}
+
+	/**
 	 * Read the Cost of Goods Sold value for a given order from the database, if available, and apply it to the order.
 	 *
 	 * @param WC_Order $order The order to get the COGS value for.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -279,6 +279,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $order->{"get_$prop"}( 'edit' );
 			$value = is_string( $value ) ? wp_slash( $value ) : $value;
+			$skip_property = false;
+
 			switch ( $prop ) {
 				case 'date_paid':
 				case 'date_completed':
@@ -301,22 +303,13 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					$value = 'yes' === $value ? 'true' : 'false'; // For backward compatibility, we store as true/false in DB.
 					break;
 				case 'cogs_total_value':
-					// Skip COGS if feature is disabled or order doesn't manage COGS.
-					if ( ! $order->has_cogs() || ! $this->cogs_is_enabled() ) {
-						continue 2; // Skip to next iteration of foreach.
-					}
-					// Apply the save filter.
-					$value = apply_filters( 'woocommerce_save_order_cogs_value', $value, $order );
-					if ( is_null( $value ) ) {
-						continue 2; // Filter returned null, skip saving.
-					}
-					// Delete meta if value is zero (optimization).
-					if ( 0.0 === (float) $value ) {
-						delete_post_meta( $id, $meta_key );
-						$updated_props[] = $prop;
-						continue 2;
-					}
+					$skip_property = $this->handle_cogs_value_update( $order, $value, $id, $meta_key, $updated_props, $prop );
 					break;
+			}
+
+			// Skip to next property if the handler indicated to do so.
+			if ( $skip_property ) {
+				continue;
 			}
 
 			// We want to persist internal data store keys as 'yes' or 'no' if they are boolean to maintain compatibility.
@@ -1435,5 +1428,40 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		$order->set_cogs_total_value( (float) $cogs_value );
 		$order->apply_changes();
+	}
+
+	/**
+	 * Handle the update of COGS value during post meta update.
+	 * This method processes COGS-specific logic and determines if the standard update flow should be skipped.
+	 *
+	 * @param WC_Order $order The order being updated.
+	 * @param mixed    &$value Reference to the COGS value to update (will be modified by filter).
+	 * @param int      $order_id The order ID.
+	 * @param string   $meta_key The meta key being updated.
+	 * @param array    &$updated_props Reference to the array of updated properties.
+	 * @param string   $prop The property name.
+	 * @return bool True if the standard update flow should be skipped, false otherwise.
+	 */
+	private function handle_cogs_value_update( $order, &$value, $order_id, $meta_key, &$updated_props, $prop ) {
+		// Skip COGS if feature is disabled or order doesn't manage COGS.
+		if ( ! $order->has_cogs() || ! $this->cogs_is_enabled() ) {
+			return true; // Skip this property.
+		}
+
+		// Apply the save filter.
+		$value = apply_filters( 'woocommerce_save_order_cogs_value', $value, $order );
+		if ( is_null( $value ) ) {
+			return true; // Filter returned null, skip saving.
+		}
+
+		// Delete meta if value is zero (optimization).
+		if ( 0.0 === (float) $value ) {
+			delete_post_meta( $order_id, $meta_key );
+			$updated_props[] = $prop;
+			return true; // Handled, skip standard flow.
+		}
+
+		// Let the standard flow handle the update (with the filtered value).
+		return false;
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -277,6 +277,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
+			// Skip COGS property if feature is disabled to avoid triggering "doing it wrong" notices.
+			if ( 'cogs_total_value' === $prop && ! $this->cogs_is_enabled() ) {
+				continue;
+			}
+
 			$value = $order->{"get_$prop"}( 'edit' );
 			$value = is_string( $value ) ? wp_slash( $value ) : $value;
 			$skip_property = false;

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1418,30 +1418,28 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		// Sync COGS value during backfill if needed (for compatibility mode).
 		// Check if COGS is enabled first to avoid triggering "doing it wrong" notices.
-		if ( ! $this->cogs_is_enabled() ) {
+		if ( ! $this->cogs_is_enabled() || ! $order->has_cogs() ) {
 			return;
 		}
 
-		if ( $order->has_cogs() ) {
-			$cogs_value = $order->get_cogs_total_value( 'edit' );
+		$cogs_value = $order->get_cogs_total_value( 'edit' );
 
-			/**
-			 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
-			 * or to suppress the saving of the value (so that custom storage can be used).
-			 *
-			 * @since 9.5.0
-			 *
-			 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
-			 * @param WC_Abstract_Order $item The order for which the value is being saved.
-			 */
-			$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
+		/**
+		 * Filter to customize the Cost of Goods Sold value that gets saved for a given order,
+		 * or to suppress the saving of the value (so that custom storage can be used).
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param float|null $cogs_value The value to be written to the database. If returned as null, nothing will be written.
+		 * @param WC_Abstract_Order $item The order for which the value is being saved.
+		 */
+		$cogs_value = apply_filters( 'woocommerce_save_order_cogs_value', $cogs_value, $order );
 
-			if ( ! is_null( $cogs_value ) ) {
-				if ( 0.0 === (float) $cogs_value ) {
-					delete_post_meta( $order->get_id(), '_cogs_total_value' );
-				} else {
-					update_post_meta( $order->get_id(), '_cogs_total_value', $cogs_value );
-				}
+		if ( ! is_null( $cogs_value ) ) {
+			if ( 0.0 === (float) $cogs_value ) {
+				delete_post_meta( $order->get_id(), '_cogs_total_value' );
+			} else {
+				update_post_meta( $order->get_id(), '_cogs_total_value', $cogs_value );
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
@@ -22,7 +22,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 	 * @since 3.0.0
 	 * @var array
 	 */
-	protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data' );
+	protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data', '_cogs_value' );
 
 	/**
 	 * Read/populate data properties specific to this order item.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1686,6 +1686,14 @@ WHERE
 		$diff                 = $this->migrate_meta_data_from_post_order( $order, $post_order );
 		$post_order_base_data = $post_order->get_base_data();
 		foreach ( $post_order_base_data as $key => $value ) {
+			// Skip migrating cogs_total_value if the HPOS order has a valid value and the CPT order has 0.
+			// This prevents overwriting valid COGS data with recalculated zero values during sync-on-read.
+			if ( 'cogs_total_value' === $key && $order->has_cogs() && $this->cogs_is_enabled() ) {
+				$hpos_cogs = $order->get_cogs_total_value( 'edit' );
+				if ( $hpos_cogs > 0 && 0.0 === (float) $value ) {
+					continue;
+				}
+			}
 			$this->set_order_prop( $order, $key, $value );
 		}
 		$this->persist_updates( $order, false );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -102,6 +102,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		'_download_permissions_granted',
 		'_order_stock_reduced',
 		'_new_order_email_sent',
+		'_cogs_total_value',
 	);
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -843,6 +843,25 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper method to create a test data store with protected methods exposed as public.
+	 *
+	 * @return WC_Order_Data_Store_CPT Data store with public method overrides.
+	 */
+	private function get_test_data_store() {
+		// phpcs:disable Squiz.Commenting
+		return new class() extends WC_Order_Data_Store_CPT {
+			public function get_internal_meta_keys() {
+				return $this->internal_meta_keys;
+			}
+
+			public function update_order_meta_from_object( $order ) {
+				parent::update_order_meta_from_object( $order );
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+	}
+
+	/**
 	 * @testDox Saving an order does not persist its Cost of Goods Sold total value if the feature is disabled.
 	 */
 	public function test_saving_order_does_not_save_cogs_value_if_cogs_disabled() {
@@ -1058,13 +1077,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testDox _cogs_total_value is included in internal meta keys to prevent it from showing as custom field.
 	 */
 	public function test_cogs_total_value_is_internal_meta() {
-		// phpcs:disable Squiz.Commenting
-		$data_store = new class() extends WC_Order_Data_Store_CPT {
-			public function get_internal_meta_keys() {
-				return $this->internal_meta_keys;
-			}
-		};
-		// phpcs:enable Squiz.Commenting
+		$data_store = $this->get_test_data_store();
 
 		$this->assertContains( '_cogs_total_value', $data_store->get_internal_meta_keys(), 'COGS total value should be in internal meta keys' );
 	}
@@ -1097,13 +1110,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
 
 		// Simulate what happens during compatibility mode backfill.
-		// phpcs:disable Squiz.Commenting
-		$data_store = new class() extends WC_Order_Data_Store_CPT {
-			public function update_order_meta_from_object( $order ) {
-				parent::update_order_meta_from_object( $order );
-			}
-		};
-		// phpcs:enable Squiz.Commenting
+		$data_store = $this->get_test_data_store();
 
 		// Call update_order_meta_from_object which should sync COGS.
 		$data_store->update_order_meta_from_object( $modified_order );
@@ -1147,14 +1154,8 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		// Set it to the expected value to simulate an HPOS order with COGS that needs to be synced.
 		$fresh_order->set_cogs_total_value( $expected_cogs );
 
-		// Create an anonymous class to access the protected method.
-		// phpcs:disable Squiz.Commenting
-		$data_store = new class() extends WC_Order_Data_Store_CPT {
-			public function update_order_meta_from_object( $order ) {
-				parent::update_order_meta_from_object( $order );
-			}
-		};
-		// phpcs:enable Squiz.Commenting
+		// Create a test data store to access the protected method.
+		$data_store = $this->get_test_data_store();
 
 		// Call update_order_meta_from_object which should sync COGS.
 		$data_store->update_order_meta_from_object( $fresh_order );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1060,4 +1060,40 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		$this->assertContains( '_cogs_total_value', $internal_keys, 'COGS total value should be in internal meta keys' );
 	}
+
+	/**
+	 * @testDox COGS value is included in the meta_key_to_props mapping for compatibility mode sync.
+	 */
+	public function test_cogs_in_meta_key_to_props_for_sync() {
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, 10.50, 2 ); // 2 items at 10.50 each = 21.00
+		$order->calculate_cogs_total_value();
+		$this->assertEquals( 21.00, $order->get_cogs_total_value() );
+
+		// Create a modified order with different COGS value.
+		$modified_order = clone $order;
+		$modified_order->set_cogs_total_value( 42.00 );
+
+		// Simulate what happens during compatibility mode backfill.
+		$data_store = new WC_Order_Data_Store_CPT();
+
+		// Use reflection to call update_post_meta directly.
+		$update_method = new \ReflectionMethod( $data_store, 'update_post_meta' );
+		$update_method->setAccessible( true );
+
+		// Save the order first.
+		$order->save();
+
+		// Now "sync" the modified value using update_post_meta.
+		$update_method->invoke( $data_store, $modified_order );
+
+		// Verify the COGS value was synced to the database.
+		$this->assertEquals( 42.00, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		// Reload and verify.
+		$reloaded_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 42.00, $reloaded_order->get_cogs_total_value() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1283,4 +1283,53 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_cogs, $reloaded_item->get_cogs_value(), 'Item without saved COGS should calculate from product' );
 		$this->assertEquals( $expected_cogs, $reloaded_order->get_cogs_total_value(), 'Order total should reflect calculated item COGS' );
 	}
+
+	/**
+	 * @testDox Refund items always recalculate COGS based on their negative quantity.
+	 */
+	public function test_refund_items_recalculate_cogs() {
+		$this->enable_cogs_feature();
+
+		$product_cost = 20.00;
+		$product_qty  = 10;
+		$refund_qty   = 3;
+		$expected_order_cogs = $product_cost * $product_qty;
+		$expected_refund_cogs = -( $product_cost * $refund_qty );
+
+		// Create an order with COGS.
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
+		$order->calculate_totals();
+		$order->save();
+
+		$this->assertEquals( $expected_order_cogs, $order->get_cogs_total_value() );
+
+		// Get the order item.
+		$order_items = array_values( $order->get_items( 'line_item' ) );
+		$order_item  = $order_items[0];
+
+		// Create a refund.
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $product_cost * $refund_qty * $product_qty / $product_qty,
+				'reason'     => 'testing',
+				'line_items' => array(
+					$order_item->get_id() => array(
+						'qty'          => $refund_qty,
+						'refund_total' => $product_cost * $refund_qty,
+					),
+				),
+			)
+		);
+		$refund->save();
+
+		// Verify the refund has the correct COGS (negative value).
+		$this->assertEquals( $expected_refund_cogs, $refund->get_cogs_total_value(), 'Refund should have negative COGS' );
+
+		// Recalculate order totals and verify COGS is adjusted for the refund.
+		$order->calculate_totals();
+		$expected_final_cogs = $expected_order_cogs + $expected_refund_cogs;
+		$this->assertEquals( $expected_final_cogs, $order->get_cogs_total_value(), 'Order COGS should be reduced by refund amount' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -3,6 +3,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareUnitTestSuiteTrait;
 
 //phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Legacy class name.
 /**
@@ -11,6 +12,7 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  * @group order-query-tests
  */
 class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+	use CogsAwareUnitTestSuiteTrait;
 	/**
 	 * Store the COT state before the test.
 	 *
@@ -38,6 +40,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		OrderHelper::toggle_cot_feature_and_usage( $this->prev_cot_state );
 		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
+		$this->disable_cogs_feature();
 		parent::tearDown();
 	}
 
@@ -819,5 +822,242 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		foreach ( $orders as $order ) {
 			$order->delete( true );
 		}
+	}
+
+	/**
+	 * Helper method to add a product with COGS value to an order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param float    $cogs_value COGS value for the product.
+	 * @param int      $quantity Quantity of the product.
+	 */
+	private function add_product_with_cogs_to_order( WC_Order $order, float $cogs_value, int $quantity ) {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_cogs_value( $cogs_value );
+		$product->save();
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( $quantity );
+		$item->save();
+		$order->add_item( $item );
+	}
+
+	/**
+	 * @testDox Saving an order does not persist its Cost of Goods Sold total value if the feature is disabled.
+	 */
+	public function test_saving_order_does_not_save_cogs_value_if_cogs_disabled() {
+		$this->expect_doing_it_wrong_cogs_disabled( 'WC_Abstract_Order::set_cogs_total_value' );
+
+		$order = new WC_Order();
+		$order->set_cogs_total_value( 12.34 );
+		$order->save();
+
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
+	}
+
+	/**
+	 * @testDox Saving an order does not persist its Cost of Goods Sold total value if the feature is enabled but the order doesn't manage it.
+	 */
+	public function test_saving_order_does_not_save_cogs_value_if_order_has_no_cogs() {
+		$this->enable_cogs_feature();
+
+		// phpcs:disable Squiz.Commenting
+		$order = new class() extends WC_Order {
+			public function has_cogs(): bool {
+				return false;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+		$order->set_cogs_total_value( 12.34 );
+		$order->save();
+
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
+	}
+
+	/**
+	 * @testDox Saving an order persists its Cost of Goods Sold total value if the feature is enabled and the order manages it.
+	 */
+	public function test_saving_order_saves_cogs_value_if_not_zero_and_cogs_enabled() {
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$order->set_cogs_total_value( 12.34 );
+		$order->save();
+
+		$this->assertEquals( 12.34, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		$order->set_cogs_total_value( 56.78 );
+		$order->save();
+
+		$this->assertEquals( 56.78, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		$order->set_cogs_total_value( 0 );
+		$order->save();
+
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
+	}
+
+	/**
+	 * @testDox Loading an order reads its Cost of Goods Sold value from the database if the feature is enabled and the order manages it.
+	 *
+	 * @testWith [true, false]
+	 *           [false, true]
+	 *           [true, true]
+	 *           [false, false]
+	 *
+	 * @param bool $cogs_enabled True if the feature is enabled.
+	 * @param bool $order_has_cogs True if the order manages COGS.
+	 */
+	public function test_loading_order_loads_cogs_value_if_cogs_enabled( bool $cogs_enabled, bool $order_has_cogs ) {
+		if ( $cogs_enabled ) {
+			$this->enable_cogs_feature();
+		} elseif ( $order_has_cogs ) {
+			$this->expect_doing_it_wrong_cogs_disabled( 'WC_Abstract_Order::get_cogs_total_value' );
+		}
+
+		$order = new WC_Order();
+		$order->save();
+
+		$saved_meta = get_post_meta( $order->get_id(), '_cogs_total_value', true );
+		if ( $saved_meta ) {
+			delete_post_meta( $order->get_id(), '_cogs_total_value' );
+		}
+
+		update_post_meta( $order->get_id(), '_cogs_total_value', '12.34' );
+
+		if ( $order_has_cogs ) {
+			$order2 = wc_get_order( $order->get_id() );
+		} else {
+			// phpcs:disable Squiz.Commenting
+			$order2 = new class($order->get_id()) extends WC_Order {
+				public function has_cogs(): bool {
+					return false;
+				}
+			};
+			// phpcs:enable Squiz.Commenting
+		}
+		$this->assertEquals( ( $cogs_enabled && $order_has_cogs ) ? 12.34 : 0, $order2->get_cogs_total_value() );
+	}
+
+	/**
+	 * @testDox It's possible to modify the Cost of Goods Sold value that gets loaded from the database for an order using the 'woocommerce_load_order_cogs_value' filter.
+	 */
+	public function test_loaded_cogs_value_can_be_modified_via_filter() {
+		$received_filter_cogs_value = null;
+		$received_filter_item       = null;
+
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$order->set_cogs_total_value( 12.34 );
+		$order->save();
+
+		add_filter(
+			'woocommerce_load_order_cogs_value',
+			function ( $cogs_value, $item ) use ( &$received_filter_cogs_value, &$received_filter_item ) {
+				$received_filter_cogs_value = $cogs_value;
+				$received_filter_item       = $item;
+				return 56.78;
+			},
+			10,
+			2
+		);
+
+		$order2 = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 12.34, $received_filter_cogs_value );
+		$this->assertSame( $order2, $received_filter_item );
+		$this->assertEquals( 56.78, $order2->get_cogs_total_value() );
+	}
+
+	/**
+	 * @testDox It's possible to modify the Cost of Goods Sold value that gets persisted for an order using the 'woocommerce_save_order_cogs_value' filter, returning null suppresses the saving.
+	 *
+	 * @testWith [56.78, "56.78"]
+	 *           [null, "12.34"]
+	 *
+	 * @param mixed  $filter_return_value The value that the filter will return.
+	 * @param string $expected_saved_value The value that is expected to be persisted after the save attempt.
+	 */
+	public function test_saved_cogs_value_can_be_altered_via_filter_with_null_meaning_dont_save( $filter_return_value, string $expected_saved_value ) {
+		$received_filter_cogs_value = null;
+		$received_filter_item       = null;
+
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$order->set_cogs_total_value( 12.34 );
+		$order->save();
+
+		add_filter(
+			'woocommerce_save_order_cogs_value',
+			function ( $cogs_value, $item ) use ( &$received_filter_cogs_value, &$received_filter_item, $filter_return_value ) {
+				$received_filter_cogs_value = $cogs_value;
+				$received_filter_item       = $item;
+				return $filter_return_value;
+			},
+			10,
+			2
+		);
+
+		$order->set_cogs_total_value( 56.78 );
+		$order->save();
+
+		$this->assertEquals( 56.78, $received_filter_cogs_value );
+		$this->assertSame( $order, $received_filter_item );
+
+		$this->assertEquals( $expected_saved_value, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+	}
+
+	/**
+	 * @testDox COGS total value is correctly calculated and persisted when HPOS is disabled.
+	 */
+	public function test_cogs_total_value_calculated_and_persisted_with_cpt() {
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, 12.34, 2 ); // 2 items at 12.34 each = 24.68
+		$this->add_product_with_cogs_to_order( $order, 5.50, 3 );  // 3 items at 5.50 each = 16.50
+		// Total COGS should be 24.68 + 16.50 = 41.18
+
+		$order->calculate_cogs_total_value();
+		$order->save();
+
+		// Verify COGS is saved to database.
+		$this->assertEquals( 41.18, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		// Verify COGS is loaded correctly when order is retrieved.
+		$loaded_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 41.18, $loaded_order->get_cogs_total_value() );
+	}
+
+	/**
+	 * @testDox COGS total value is zero when order has no items with COGS.
+	 */
+	public function test_cogs_total_value_zero_when_no_cogs_items() {
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$order->calculate_cogs_total_value();
+		$order->save();
+
+		// Verify no COGS meta is saved when value is zero.
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
+
+		// Verify COGS value is zero when order is retrieved.
+		$loaded_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 0, $loaded_order->get_cogs_total_value() );
+	}
+
+	/**
+	 * @testDox _cogs_total_value is included in internal meta keys to prevent it from showing as custom field.
+	 */
+	public function test_cogs_total_value_is_internal_meta() {
+		$data_store       = new WC_Order_Data_Store_CPT();
+		$internal_meta    = new \ReflectionProperty( $data_store, 'internal_meta_keys' );
+		$internal_meta->setAccessible( true );
+		$internal_keys = $internal_meta->getValue( $data_store );
+
+		$this->assertContains( '_cogs_total_value', $internal_keys, 'COGS total value should be in internal meta keys' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1163,4 +1163,88 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		// Verify COGS was synced.
 		$this->assertEquals( $expected_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 	}
+
+	/**
+	 * @testDox COGS value is synced during full backfill simulation (create, set_props, update).
+	 */
+	public function test_cogs_synced_during_full_backfill_simulation() {
+		$this->enable_cogs_feature();
+
+		$product_cost  = 22.50;
+		$product_qty   = 2;
+		$expected_cogs = $product_cost * $product_qty;
+
+		// Create an order with COGS (simulating an HPOS order).
+		$hpos_order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $hpos_order, $product_cost, $product_qty );
+		$hpos_order->calculate_cogs_total_value();
+		$hpos_order->save();
+
+		$this->assertEquals( $expected_cogs, $hpos_order->get_cogs_total_value() );
+
+		// Delete the COGS meta to simulate it not being synced to CPT yet.
+		delete_post_meta( $hpos_order->get_id(), '_cogs_total_value' );
+		$this->assertFalse( metadata_exists( 'post', $hpos_order->get_id(), '_cogs_total_value' ) );
+
+		// Simulate what happens in OrdersTableDataStore::backfill_post_record().
+		$cpt_data_store = new WC_Order_Data_Store_CPT();
+		$order_class    = get_class( $hpos_order );
+		$post_order     = new $order_class();
+		$post_order->set_id( $hpos_order->get_id() );
+
+		// Read the existing CPT record (which won't have COGS meta).
+		if ( $cpt_data_store->order_exists( $hpos_order->get_id() ) ) {
+			$cpt_data_store->read( $post_order );
+		}
+
+		// This simulates line 687 of OrdersTableDataStore::backfill_post_record().
+		// Set props from the HPOS order data.
+		$post_order->set_props( $hpos_order->get_data() );
+
+		// Verify that COGS was transferred via set_props.
+		$this->assertEquals( $expected_cogs, $post_order->get_cogs_total_value(), 'COGS value should be transferred to post_order via set_props' );
+
+		// Now call update_order_from_object which should sync to database.
+		$cpt_data_store->update_order_from_object( $post_order );
+
+		// Verify COGS was synced to the database.
+		$this->assertEquals( $expected_cogs, (float) get_post_meta( $hpos_order->get_id(), '_cogs_total_value', true ), 'COGS value should be synced to post meta' );
+	}
+
+	/**
+	 * @testDox Item COGS values are preserved and not recalculated when order totals are recalculated.
+	 */
+	public function test_item_cogs_values_are_preserved_on_recalculation() {
+		$this->enable_cogs_feature();
+
+		$product_cost  = 10.00;
+		$product_qty   = 5;
+		$expected_item_cogs = $product_cost * $product_qty;
+
+		// Create an order with COGS.
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
+		$order->calculate_totals();
+		$order->save();
+
+		// Verify the item has the expected COGS value saved.
+		$items = $order->get_items();
+		$item  = reset( $items );
+		$this->assertEquals( $expected_item_cogs, $item->get_cogs_value() );
+
+		// Now change the product COGS to a different value (simulating a product price update).
+		$product = $item->get_product();
+		$product->set_cogs_value( 99.99 );
+		$product->save();
+
+		// Reload the order and recalculate totals.
+		$reloaded_order = wc_get_order( $order->get_id() );
+		$reloaded_order->calculate_totals();
+
+		// The item COGS should still be the original value, not recalculated from the new product COGS.
+		$reloaded_items = $reloaded_order->get_items();
+		$reloaded_item  = reset( $reloaded_items );
+		$this->assertEquals( $expected_item_cogs, $reloaded_item->get_cogs_value(), 'Item COGS should be preserved and not recalculated from product' );
+		$this->assertEquals( $expected_item_cogs, $reloaded_order->get_cogs_total_value(), 'Order COGS total should match preserved item COGS' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1119,13 +1119,17 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		delete_post_meta( $order->get_id(), '_cogs_total_value' );
 		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
 
+		// Reload the order to get fresh state.
+		$fresh_order = wc_get_order( $order->get_id() );
+
+		// The fresh order will have 0 COGS since we deleted the meta.
+		// Set it to the expected value to simulate an HPOS order with COGS that needs to be synced.
+		$fresh_order->set_cogs_total_value( 47.25 );
+
 		// Now simulate backfill by calling update_order_meta_from_object.
 		$data_store = new WC_Order_Data_Store_CPT();
 		$update_method = new \ReflectionMethod( $data_store, 'update_order_meta_from_object' );
 		$update_method->setAccessible( true );
-
-		// Reload the order to get fresh state.
-		$fresh_order = wc_get_order( $order->get_id() );
 
 		// Call update_order_meta_from_object which should sync COGS.
 		$update_method->invoke( $data_store, $fresh_order );

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1296,9 +1296,15 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$expected_order_cogs = $product_cost * $product_qty;
 		$expected_refund_cogs = -( $product_cost * $refund_qty );
 
+		// Create a product with COGS and price.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( $product_cost );
+		$product->set_cogs_value( $product_cost );
+		$product->save();
+
 		// Create an order with COGS.
 		$order = new WC_Order();
-		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
+		$order->add_product( $product, $product_qty );
 		$order->calculate_totals();
 		$order->save();
 
@@ -1312,7 +1318,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$refund = wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => $product_cost * $refund_qty * $product_qty / $product_qty,
+				'amount'     => $product_cost * $refund_qty,
 				'reason'     => 'testing',
 				'line_items' => array(
 					$order_item->get_id() => array(
@@ -1322,6 +1328,8 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 				),
 			)
 		);
+
+		$this->assertNotInstanceOf( 'WP_Error', $refund, 'Refund creation should not return an error' );
 		$refund->save();
 
 		// Verify the refund has the correct COGS (negative value).

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1247,4 +1247,40 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_item_cogs, $reloaded_item->get_cogs_value(), 'Item COGS should be preserved and not recalculated from product' );
 		$this->assertEquals( $expected_item_cogs, $reloaded_order->get_cogs_total_value(), 'Order COGS total should match preserved item COGS' );
 	}
+
+	/**
+	 * @testDox Items without saved COGS metadata can calculate COGS from products.
+	 */
+	public function test_items_without_saved_cogs_calculate_from_product() {
+		$this->enable_cogs_feature();
+
+		$product_cost = 15.00;
+		$product_qty  = 2;
+		$expected_cogs = $product_cost * $product_qty;
+
+		// Create an order with COGS and save it.
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
+		$order->calculate_totals();
+		$order->save();
+
+		// Get the item and manually delete its _cogs_value metadata to simulate an item without saved COGS.
+		$items = $order->get_items();
+		$item  = reset( $items );
+		delete_metadata( 'order_item', $item->get_id(), '_cogs_value' );
+
+		// Reload the order.
+		$reloaded_order = wc_get_order( $order->get_id() );
+
+		// The item should not have a saved COGS value.
+		$reloaded_items = $reloaded_order->get_items();
+		$reloaded_item  = reset( $reloaded_items );
+		
+		// When we call calculate_totals, it should calculate COGS from the product.
+		$reloaded_order->calculate_totals();
+
+		// Verify the COGS was calculated correctly.
+		$this->assertEquals( $expected_cogs, $reloaded_item->get_cogs_value(), 'Item without saved COGS should calculate from product' );
+		$this->assertEquals( $expected_cogs, $reloaded_order->get_cogs_total_value(), 'Order total should reflect calculated item COGS' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1015,20 +1015,25 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	public function test_cogs_total_value_calculated_and_persisted_with_cpt() {
 		$this->enable_cogs_feature();
 
+		$product1_cost = 12.34;
+		$product1_qty  = 2;
+		$product2_cost = 5.50;
+		$product2_qty  = 3;
+		$expected_total = ( $product1_cost * $product1_qty ) + ( $product2_cost * $product2_qty );
+
 		$order = new WC_Order();
-		$this->add_product_with_cogs_to_order( $order, 12.34, 2 ); // 2 items at 12.34 each = 24.68
-		$this->add_product_with_cogs_to_order( $order, 5.50, 3 );  // 3 items at 5.50 each = 16.50
-		// Total COGS should be 24.68 + 16.50 = 41.18
+		$this->add_product_with_cogs_to_order( $order, $product1_cost, $product1_qty );
+		$this->add_product_with_cogs_to_order( $order, $product2_cost, $product2_qty );
 
 		$order->calculate_cogs_total_value();
 		$order->save();
 
 		// Verify COGS is saved to database.
-		$this->assertEquals( 41.18, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+		$this->assertEquals( $expected_total, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 
 		// Verify COGS is loaded correctly when order is retrieved.
 		$loaded_order = wc_get_order( $order->get_id() );
-		$this->assertEquals( 41.18, $loaded_order->get_cogs_total_value() );
+		$this->assertEquals( $expected_total, $loaded_order->get_cogs_total_value() );
 	}
 
 	/**
@@ -1067,17 +1072,22 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	public function test_cogs_in_meta_key_to_props_for_sync() {
 		$this->enable_cogs_feature();
 
+		$product_cost      = 10.50;
+		$product_qty       = 2;
+		$initial_cogs      = $product_cost * $product_qty;
+		$modified_cogs     = $initial_cogs * 2;
+
 		$order = new WC_Order();
-		$this->add_product_with_cogs_to_order( $order, 10.50, 2 ); // 2 items at 10.50 each = 21.00
+		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
 		$order->calculate_cogs_total_value();
 		$order->save();
 
-		$this->assertEquals( 21.00, $order->get_cogs_total_value() );
-		$this->assertEquals( 21.00, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+		$this->assertEquals( $initial_cogs, $order->get_cogs_total_value() );
+		$this->assertEquals( $initial_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 
 		// Reload the order and modify COGS value to simulate HPOS order with different value.
 		$modified_order = wc_get_order( $order->get_id() );
-		$modified_order->set_cogs_total_value( 42.00 );
+		$modified_order->set_cogs_total_value( $modified_cogs );
 
 		// Delete the post meta to simulate it not being synced yet.
 		delete_post_meta( $order->get_id(), '_cogs_total_value' );
@@ -1092,11 +1102,11 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$update_method->invoke( $data_store, $modified_order );
 
 		// Verify the COGS value was synced to the database.
-		$this->assertEquals( 42.00, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+		$this->assertEquals( $modified_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 
 		// Reload and verify.
 		$reloaded_order = wc_get_order( $order->get_id() );
-		$this->assertEquals( 42.00, $reloaded_order->get_cogs_total_value() );
+		$this->assertEquals( $modified_cogs, $reloaded_order->get_cogs_total_value() );
 	}
 
 	/**
@@ -1105,15 +1115,19 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	public function test_cogs_synced_via_update_order_meta_from_object() {
 		$this->enable_cogs_feature();
 
+		$product_cost = 15.75;
+		$product_qty  = 3;
+		$expected_cogs = $product_cost * $product_qty;
+
 		$order = new WC_Order();
-		$this->add_product_with_cogs_to_order( $order, 15.75, 3 ); // 3 items at 15.75 each = 47.25
+		$this->add_product_with_cogs_to_order( $order, $product_cost, $product_qty );
 		$order->calculate_cogs_total_value();
 		$order->save();
 
-		$this->assertEquals( 47.25, $order->get_cogs_total_value() );
+		$this->assertEquals( $expected_cogs, $order->get_cogs_total_value() );
 
 		// Verify it's in the database.
-		$this->assertEquals( 47.25, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+		$this->assertEquals( $expected_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 
 		// Delete the COGS meta to simulate it not being synced yet.
 		delete_post_meta( $order->get_id(), '_cogs_total_value' );
@@ -1124,7 +1138,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 
 		// The fresh order will have 0 COGS since we deleted the meta.
 		// Set it to the expected value to simulate an HPOS order with COGS that needs to be synced.
-		$fresh_order->set_cogs_total_value( 47.25 );
+		$fresh_order->set_cogs_total_value( $expected_cogs );
 
 		// Now simulate backfill by calling update_order_meta_from_object.
 		$data_store = new WC_Order_Data_Store_CPT();
@@ -1135,6 +1149,6 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$update_method->invoke( $data_store, $fresh_order );
 
 		// Verify COGS was synced.
-		$this->assertEquals( 47.25, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+		$this->assertEquals( $expected_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1096,4 +1096,39 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$reloaded_order = wc_get_order( $order->get_id() );
 		$this->assertEquals( 42.00, $reloaded_order->get_cogs_total_value() );
 	}
+
+	/**
+	 * @testDox COGS value is synced during backfill via update_order_meta_from_object.
+	 */
+	public function test_cogs_synced_via_update_order_meta_from_object() {
+		$this->enable_cogs_feature();
+
+		$order = new WC_Order();
+		$this->add_product_with_cogs_to_order( $order, 15.75, 3 ); // 3 items at 15.75 each = 47.25
+		$order->calculate_cogs_total_value();
+		$order->save();
+
+		$this->assertEquals( 47.25, $order->get_cogs_total_value() );
+
+		// Verify it's in the database.
+		$this->assertEquals( 47.25, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		// Delete the COGS meta to simulate it not being synced yet.
+		delete_post_meta( $order->get_id(), '_cogs_total_value' );
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
+
+		// Now simulate backfill by calling update_order_meta_from_object.
+		$data_store = new WC_Order_Data_Store_CPT();
+		$update_method = new \ReflectionMethod( $data_store, 'update_order_meta_from_object' );
+		$update_method->setAccessible( true );
+
+		// Reload the order to get fresh state.
+		$fresh_order = wc_get_order( $order->get_id() );
+
+		// Call update_order_meta_from_object which should sync COGS.
+		$update_method->invoke( $data_store, $fresh_order );
+
+		// Verify COGS was synced.
+		$this->assertEquals( 47.25, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1062,7 +1062,7 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox COGS value is included in the meta_key_to_props mapping for compatibility mode sync.
+	 * @testDox COGS value is synced via update_order_meta_from_object for compatibility mode.
 	 */
 	public function test_cogs_in_meta_key_to_props_for_sync() {
 		$this->enable_cogs_feature();
@@ -1070,23 +1070,25 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$order = new WC_Order();
 		$this->add_product_with_cogs_to_order( $order, 10.50, 2 ); // 2 items at 10.50 each = 21.00
 		$order->calculate_cogs_total_value();
-		$this->assertEquals( 21.00, $order->get_cogs_total_value() );
+		$order->save();
 
-		// Create a modified order with different COGS value.
-		$modified_order = clone $order;
+		$this->assertEquals( 21.00, $order->get_cogs_total_value() );
+		$this->assertEquals( 21.00, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
+
+		// Reload the order and modify COGS value to simulate HPOS order with different value.
+		$modified_order = wc_get_order( $order->get_id() );
 		$modified_order->set_cogs_total_value( 42.00 );
+
+		// Delete the post meta to simulate it not being synced yet.
+		delete_post_meta( $order->get_id(), '_cogs_total_value' );
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
 
 		// Simulate what happens during compatibility mode backfill.
 		$data_store = new WC_Order_Data_Store_CPT();
-
-		// Use reflection to call update_post_meta directly.
-		$update_method = new \ReflectionMethod( $data_store, 'update_post_meta' );
+		$update_method = new \ReflectionMethod( $data_store, 'update_order_meta_from_object' );
 		$update_method->setAccessible( true );
 
-		// Save the order first.
-		$order->save();
-
-		// Now "sync" the modified value using update_post_meta.
+		// Call update_order_meta_from_object which should sync COGS.
 		$update_method->invoke( $data_store, $modified_order );
 
 		// Verify the COGS value was synced to the database.

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -1058,12 +1058,15 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 	 * @testDox _cogs_total_value is included in internal meta keys to prevent it from showing as custom field.
 	 */
 	public function test_cogs_total_value_is_internal_meta() {
-		$data_store       = new WC_Order_Data_Store_CPT();
-		$internal_meta    = new \ReflectionProperty( $data_store, 'internal_meta_keys' );
-		$internal_meta->setAccessible( true );
-		$internal_keys = $internal_meta->getValue( $data_store );
+		// phpcs:disable Squiz.Commenting
+		$data_store = new class() extends WC_Order_Data_Store_CPT {
+			public function get_internal_meta_keys() {
+				return $this->internal_meta_keys;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
 
-		$this->assertContains( '_cogs_total_value', $internal_keys, 'COGS total value should be in internal meta keys' );
+		$this->assertContains( '_cogs_total_value', $data_store->get_internal_meta_keys(), 'COGS total value should be in internal meta keys' );
 	}
 
 	/**
@@ -1094,12 +1097,16 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_cogs_total_value' ) );
 
 		// Simulate what happens during compatibility mode backfill.
-		$data_store = new WC_Order_Data_Store_CPT();
-		$update_method = new \ReflectionMethod( $data_store, 'update_order_meta_from_object' );
-		$update_method->setAccessible( true );
+		// phpcs:disable Squiz.Commenting
+		$data_store = new class() extends WC_Order_Data_Store_CPT {
+			public function update_order_meta_from_object( $order ) {
+				parent::update_order_meta_from_object( $order );
+			}
+		};
+		// phpcs:enable Squiz.Commenting
 
 		// Call update_order_meta_from_object which should sync COGS.
-		$update_method->invoke( $data_store, $modified_order );
+		$data_store->update_order_meta_from_object( $modified_order );
 
 		// Verify the COGS value was synced to the database.
 		$this->assertEquals( $modified_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );
@@ -1140,13 +1147,17 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		// Set it to the expected value to simulate an HPOS order with COGS that needs to be synced.
 		$fresh_order->set_cogs_total_value( $expected_cogs );
 
-		// Now simulate backfill by calling update_order_meta_from_object.
-		$data_store = new WC_Order_Data_Store_CPT();
-		$update_method = new \ReflectionMethod( $data_store, 'update_order_meta_from_object' );
-		$update_method->setAccessible( true );
+		// Create an anonymous class to access the protected method.
+		// phpcs:disable Squiz.Commenting
+		$data_store = new class() extends WC_Order_Data_Store_CPT {
+			public function update_order_meta_from_object( $order ) {
+				parent::update_order_meta_from_object( $order );
+			}
+		};
+		// phpcs:enable Squiz.Commenting
 
 		// Call update_order_meta_from_object which should sync COGS.
-		$update_method->invoke( $data_store, $fresh_order );
+		$data_store->update_order_meta_from_object( $fresh_order );
 
 		// Verify COGS was synced.
 		$this->assertEquals( $expected_cogs, (float) get_post_meta( $order->get_id(), '_cogs_total_value', true ) );


### PR DESCRIPTION
Add Cost of Goods Sold (COGS) data persistence to `WC_Order_Data_Store_CPT` to ensure COGS values are correctly saved and loaded when HPOS is disabled.

When High-Performance Order Storage (HPOS) is disabled, the `WC_Order_Data_Store_CPT` class is responsible for handling order data. This class was missing the necessary logic to read and save the `_cogs_total_value` meta, causing the total COGS for an order to appear as zero, even if individual items had costs. This PR implements the missing persistence logic, aligning its behavior with the HPOS data store and resolving the issue reported in #61292.

---
<a href="https://cursor.com/background-agent?bcId=bc-14f82e1c-9b8d-4102-8265-0cfccf88063a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14f82e1c-9b8d-4102-8265-0cfccf88063a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

