### PR TITLE
Remove redundant is_collection cache info

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareRestControllerTrait;
+use Automattic\WooCommerce\Internal\Traits\RestApiCache;
 use Automattic\WooCommerce\Utilities\I18nUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -26,6 +27,7 @@ use Automattic\Jetpack\Constants;
  */
 class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V2_Controller {
 	use CogsAwareRestControllerTrait;
+	use RestApiCache;
 
 	/**
 	 * Endpoint namespace.
@@ -33,6 +35,14 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->register_cache_hooks();
+	}
 
 	/**
 	 * Product statuses to exclude from the query.
@@ -1313,5 +1323,103 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		}
 
 		return $where;
+	}
+
+	/* -------------------------------------------------------------------------
+	 * REST API Caching Implementation
+	 * ------------------------------------------------------------------------- */
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Cache key info or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		$matched_route = $this->get_matched_route( $request );
+
+		if ( ! $matched_route ) {
+			return null;
+		}
+
+		// Generate hash from query params for cache key differentiation.
+		$query_hash = md5( wp_json_encode( $request->get_query_params() ) );
+
+		switch ( $matched_route ) {
+			case '/wc/v3/' . $this->rest_base . '/(?P<id>[\d]+)':
+				// Single variation endpoint.
+				$variation_id = $request->get_param( 'id' );
+				return array(
+					'key'       => 'wc_rest_variation_' . $variation_id . '_' . $query_hash,
+					'entity_id' => $variation_id,
+				);
+
+			case '/wc/v3/' . $this->rest_base . '/generate':
+				// Generate endpoint - skip caching (modifies data).
+				return null;
+
+			case '/wc/v3/' . $this->rest_base:
+				// Variations collection endpoint.
+				$product_id = $request->get_param( 'product_id' );
+				return array(
+					'key' => 'wc_rest_variations_collection_' . $product_id . '_' . $query_hash,
+				);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array(
+			'woocommerce_rest_prepare_product_variation_object',
+			'rest_prepare_product_variation',
+		);
+	}
+
+	/**
+	 * Extract variation IDs from response data.
+	 *
+	 * For variations, we need to track both the variation ID and parent product ID
+	 * for proper cache invalidation.
+	 *
+	 * @param array $data Response data.
+	 * @return array Variation and parent product IDs.
+	 */
+	protected function extract_entity_ids( $data ) {
+		$ids = array();
+
+		if ( $this->is_collection( $data ) ) {
+			// Collection response
+			foreach ( $data as $item ) {
+				$id = $this->extract_entity_id( $item );
+				if ( null !== $id ) {
+					$ids[] = $id;
+
+					// Also track parent product ID for cache invalidation.
+					if ( isset( $item['parent_id'] ) && $item['parent_id'] > 0 ) {
+						$ids[] = $item['parent_id'];
+					}
+				}
+			}
+		} else {
+			// Single variation response
+			$id = $this->extract_entity_id( $data );
+			if ( null !== $id ) {
+				$ids[] = $id;
+
+				// Also track parent product ID.
+				if ( isset( $data['parent_id'] ) && $data['parent_id'] > 0 ) {
+					$ids[] = $data['parent_id'];
+				}
+			}
+		}
+
+		return array_unique( array_filter( $ids ) );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
 use Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareRestControllerTrait;
+use Automattic\WooCommerce\Internal\Traits\RestApiCache;
 use Automattic\WooCommerce\Utilities\I18nUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,6 +28,7 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 	use CogsAwareRestControllerTrait;
+	use RestApiCache;
 
 	/**
 	 * Endpoint namespace.
@@ -34,6 +36,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->register_cache_hooks();
+	}
 
 	/**
 	 * The value of the 'search_sku' argument if present.
@@ -2148,5 +2158,95 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$this->processed_attachment_ids_for_request = array();
 
 		return $response;
+	}
+
+	/* -------------------------------------------------------------------------
+	 * REST API Caching Implementation
+	 * ------------------------------------------------------------------------- */
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Cache key info or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		$matched_route = $this->get_matched_route( $request );
+
+		if ( ! $matched_route ) {
+			return null;
+		}
+
+		// Generate hash from query params for cache key differentiation.
+		$query_hash = md5( wp_json_encode( $request->get_query_params() ) );
+
+		switch ( $matched_route ) {
+			case '/wc/v3/' . $this->rest_base . '/(?P<id>[\d]+)':
+				// Single product endpoint.
+				$product_id = $request->get_param( 'id' );
+				return array(
+					'key'       => 'wc_rest_product_' . $product_id . '_' . $query_hash,
+					'entity_id' => $product_id,
+				);
+
+			case '/wc/v3/' . $this->rest_base . '/(?P<id>[\d]+)/duplicate':
+				// Duplicate endpoint - skip caching (creates new product).
+				return null;
+
+			case '/wc/v3/' . $this->rest_base:
+			case '/wc/v3/' . $this->rest_base . '/suggested-products':
+				// Collection endpoints.
+				return array(
+					'key' => 'wc_rest_products_collection_' . md5( $matched_route . $query_hash ),
+				);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array(
+			'woocommerce_rest_prepare_product_object',
+			'rest_prepare_product',
+			'woocommerce_rest_product_object_query',
+		);
+	}
+
+	/**
+	 * Remove non-deterministic fields from data for ETag generation.
+	 *
+	 * @param array $data Response data.
+	 * @return array Cleaned data.
+	 */
+	protected function remove_non_deterministic_fields( $data ) {
+		if ( $this->is_collection( $data ) ) {
+			// Collection response - remove related_ids from each product.
+			$clean_data = array();
+			foreach ( $data as $key => $product ) {
+				if ( isset( $product['related_ids'] ) ) {
+					$clean_product = $product;
+					unset( $clean_product['related_ids'] );
+					$clean_data[ $key ] = $clean_product;
+				} else {
+					$clean_data[ $key ] = $product;
+				}
+			}
+			return $clean_data;
+		}
+
+		// Single product response - remove related_ids.
+		if ( isset( $data['related_ids'] ) ) {
+			$clean_data = $data;
+			unset( $clean_data['related_ids'] );
+			return $clean_data;
+		}
+
+		return $data;
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/examples/example-products-controller-with-caching.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/examples/example-products-controller-with-caching.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Example: How to implement REST API caching in WC_REST_Products_Controller
+ * 
+ * This demonstrates how to extend WC_REST_Controller with entity-specific caching logic.
+ */
+
+/**
+ * Example implementation - DO NOT USE DIRECTLY
+ * This is a reference implementation showing how to add caching to the products controller.
+ * The actual implementation is in class-wc-rest-products-controller.php
+ */
+class Example_WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
+
+	/**
+	 * Enable caching for this controller.
+	 *
+	 * @var bool
+	 */
+	protected $cache_enabled = true;
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Cache key info or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		$route = $request->get_route();
+
+		// Single product: /wc/v3/products/{id}
+		if ( preg_match( '#^/wc/v3/products/(\d+)$#', $route, $matches ) ) {
+			return array(
+				'key'       => 'wc_rest_product_' . $matches[1],
+				'entity_id' => (int) $matches[1],
+			);
+		}
+
+		// Collection endpoints: /wc/v3/products, /wc/v3/products/suggested-products
+		if ( strpos( $route, '/wc/v3/products' ) !== false ) {
+			$query_hash = md5( wp_json_encode( $request->get_query_params() ) );
+			return array(
+				'key' => 'wc_rest_collection_' . md5( $route . $query_hash ),
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array(
+			'woocommerce_rest_prepare_product_object',
+			'rest_prepare_product',
+			'woocommerce_rest_product_object_query',
+		);
+	}
+
+	// Note: extract_entity_ids() is now provided by the base class.
+	// It uses extract_entity_id() which defaults to $entity['id'] ?? null.
+	// No need to override unless you have special ID extraction logic.
+
+	/**
+	 * Remove non-deterministic fields from data.
+	 *
+	 * @param array $data Response data.
+	 * @return array Cleaned data.
+	 */
+	protected function remove_non_deterministic_fields( $data ) {
+		if ( $this->is_collection( $data ) ) {
+			// Collection response
+			$clean_data = array();
+			foreach ( $data as $key => $product ) {
+				if ( isset( $product['related_ids'] ) ) {
+					$clean_product = $product;
+					unset( $clean_product['related_ids'] );
+					$clean_data[ $key ] = $clean_product;
+				} else {
+					$clean_data[ $key ] = $product;
+				}
+			}
+			return $clean_data;
+		}
+		
+		// Single product response
+		if ( isset( $data['related_ids'] ) ) {
+			$clean_data = $data;
+			unset( $clean_data['related_ids'] );
+			return $clean_data;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get cache key for a single product.
+	 *
+	 * @param int $entity_id Product ID.
+	 * @return string Cache key.
+	 */
+	protected function get_single_entity_cache_key( $entity_id ) {
+		return 'wc_rest_product_' . $entity_id;
+	}
+}
+
+/**
+ * Hook into product changes to invalidate caches
+ */
+add_action( 'woocommerce_update_product', 'wc_invalidate_product_rest_cache', 10, 1 );
+add_action( 'woocommerce_new_product', 'wc_invalidate_product_rest_cache', 10, 1 );
+add_action( 'woocommerce_delete_product', 'wc_invalidate_product_rest_cache', 10, 1 );
+
+function wc_invalidate_product_rest_cache( $product_id ) {
+	// Get the products controller instance
+	// In practice, you might store this as a global or singleton
+	$controller = new WC_REST_Products_Controller();
+	
+	// Invalidate cache for this product
+	$controller->invalidate_entity_cache( $product_id );
+	
+	// For variations, also invalidate parent
+	$product = wc_get_product( $product_id );
+	if ( $product && $product->is_type( 'variation' ) ) {
+		$parent_id = $product->get_parent_id();
+		if ( $parent_id ) {
+			$controller->invalidate_entity_cache( $parent_id );
+		}
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/examples/example-restapi-controllerbase-with-caching.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/examples/example-restapi-controllerbase-with-caching.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Example: How to implement REST API caching with RestApiControllerBase
+ * 
+ * This demonstrates how to use the WC_REST_Cacheable trait with the newer
+ * RestApiControllerBase class used in src/Internal controllers.
+ */
+
+namespace Automattic\WooCommerce\Internal\Example;
+
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Example controller using RestApiControllerBase with caching.
+ */
+class CustomEntityController extends RestApiControllerBase {
+
+	/**
+	 * Enable caching for this controller.
+	 *
+	 * @var bool
+	 */
+	protected $cache_enabled = true;
+
+	/**
+	 * Get the WooCommerce REST API namespace.
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'custom-entities';
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		// Single entity endpoint
+		register_rest_route(
+			$this->route_namespace,
+			'/custom-entities/(?P<id>[\d]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'get_entity' ),
+					'permission_callback' => fn( $request ) => $this->check_permission( $request, 'read', $request->get_param( 'id' ) ),
+				),
+			)
+		);
+
+		// Collection endpoint
+		register_rest_route(
+			$this->route_namespace,
+			'/custom-entities',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'get_entities' ),
+					'permission_callback' => fn( $request ) => $this->check_permission( $request, 'read' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get a single entity.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Entity data.
+	 */
+	protected function get_entity( WP_REST_Request $request ) {
+		$entity_id = $request->get_param( 'id' );
+		
+		// Your logic to fetch entity
+		return array(
+			'id'   => $entity_id,
+			'name' => 'Entity ' . $entity_id,
+			'data' => 'Some data',
+		);
+	}
+
+	/**
+	 * Get multiple entities.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Array of entities.
+	 */
+	protected function get_entities( WP_REST_Request $request ) {
+		// Your logic to fetch entities
+		return array(
+			array( 'id' => 1, 'name' => 'Entity 1' ),
+			array( 'id' => 2, 'name' => 'Entity 2' ),
+			array( 'id' => 3, 'name' => 'Entity 3' ),
+		);
+	}
+
+	/* -------------------------------------------------------------------------
+	 * Caching Implementation - Override these methods from WC_REST_Cacheable
+	 * ------------------------------------------------------------------------- */
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Cache key info or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		$route = $request->get_route();
+
+		// Single entity: /wc/v3/custom-entities/{id}
+		if ( preg_match( '#^/wc/v3/custom-entities/(\d+)$#', $route, $matches ) ) {
+			return array(
+				'key'       => 'wc_rest_custom_entity_' . $matches[1],
+				'entity_id' => (int) $matches[1],
+			);
+		}
+
+		// Collection endpoint: /wc/v3/custom-entities
+		if ( strpos( $route, '/wc/v3/custom-entities' ) !== false ) {
+			$query_hash = md5( wp_json_encode( $request->get_query_params() ) );
+			return array(
+				'key' => 'wc_rest_custom_entities_collection_' . $query_hash,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array(
+			'woocommerce_rest_prepare_custom_entity',
+			// Add any other filters that modify the response
+		);
+	}
+
+	/**
+	 * Get cache key for a single entity.
+	 *
+	 * @param int $entity_id Entity ID.
+	 * @return string Cache key.
+	 */
+	protected function get_single_entity_cache_key( $entity_id ) {
+		return 'wc_rest_custom_entity_' . $entity_id;
+	}
+
+	/**
+	 * Override matches_route for RestApiControllerBase pattern.
+	 *
+	 * @param string $route Request route.
+	 * @return bool True if route matches this controller.
+	 */
+	protected function matches_route( $route ) {
+		// RestApiControllerBase uses $route_namespace instead of $namespace
+		return strpos( $route, '/' . $this->route_namespace . '/custom-entities' ) !== false;
+	}
+
+	// Note: extract_entity_ids() is provided by the trait.
+	// Note: remove_non_deterministic_fields() - override if needed.
+}
+
+/**
+ * Hook into entity changes to invalidate caches.
+ */
+add_action( 'custom_entity_updated', function( $entity_id ) {
+	$container  = wc_get_container();
+	$controller = $container->get( CustomEntityController::class );
+	$controller->invalidate_entity_cache( $entity_id );
+}, 10, 1 );

--- a/plugins/woocommerce/includes/rest-api/Controllers/examples/example-variations-controller-with-caching.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/examples/example-variations-controller-with-caching.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Example: How to implement REST API caching in WC_REST_Product_Variations_Controller
+ * 
+ * This demonstrates how the same caching system works for variations.
+ */
+
+/**
+ * Example implementation - DO NOT USE DIRECTLY
+ * This is a reference implementation showing how to add caching to the variations controller.
+ * The actual implementation is in class-wc-rest-product-variations-controller.php
+ */
+class Example_WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V2_Controller {
+
+	/**
+	 * Enable caching for this controller.
+	 *
+	 * @var bool
+	 */
+	protected $cache_enabled = true;
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Cache key info or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		$route = $request->get_route();
+
+		// Single variation: /wc/v3/products/{product_id}/variations/{id}
+		if ( preg_match( '#^/wc/v3/products/\d+/variations/(\d+)$#', $route, $matches ) ) {
+			return array(
+				'key'       => 'wc_rest_variation_' . $matches[1],
+				'entity_id' => (int) $matches[1],
+			);
+		}
+
+		// Variations collection: /wc/v3/products/{product_id}/variations
+		if ( preg_match( '#^/wc/v3/products/(\d+)/variations$#', $route, $matches ) ) {
+			$query_hash = md5( wp_json_encode( $request->get_query_params() ) );
+			return array(
+				'key' => 'wc_rest_variations_collection_' . $matches[1] . '_' . $query_hash,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array(
+			'woocommerce_rest_prepare_product_variation_object',
+			'rest_prepare_product_variation',
+		);
+	}
+
+	/**
+	 * Extract variation IDs from response data.
+	 * 
+	 * For variations, we need to track both the variation ID and parent product ID
+	 * for proper cache invalidation.
+	 *
+	 * @param array $data Response data.
+	 * @return array Variation and parent product IDs.
+	 */
+	protected function extract_entity_ids( $data ) {
+		$ids = array();
+
+		if ( $this->is_collection( $data ) ) {
+			// Collection response
+			foreach ( $data as $item ) {
+				$id = $this->extract_entity_id( $item );
+				if ( null !== $id ) {
+					$ids[] = $id;
+					
+					// Also track parent product ID for cache invalidation
+					if ( isset( $item['parent_id'] ) && $item['parent_id'] > 0 ) {
+						$ids[] = $item['parent_id'];
+					}
+				}
+			}
+		} else {
+			// Single variation response
+			$id = $this->extract_entity_id( $data );
+			if ( null !== $id ) {
+				$ids[] = $id;
+				
+				// Also track parent product ID
+				if ( isset( $data['parent_id'] ) && $data['parent_id'] > 0 ) {
+					$ids[] = $data['parent_id'];
+				}
+			}
+		}
+
+		return array_unique( array_filter( $ids ) );
+	}
+
+	/**
+	 * Remove non-deterministic fields from data.
+	 *
+	 * Variations don't have related_ids, but this method is still required.
+	 *
+	 * @param array $data Response data.
+	 * @return array Cleaned data.
+	 */
+	protected function remove_non_deterministic_fields( $data ) {
+		// Variations don't have random fields by default
+		return $data;
+	}
+
+	/**
+	 * Get cache key for a single variation.
+	 *
+	 * @param int $entity_id Variation ID.
+	 * @return string Cache key.
+	 */
+	protected function get_single_entity_cache_key( $entity_id ) {
+		return 'wc_rest_variation_' . $entity_id;
+	}
+}
+
+/**
+ * Hook into variation changes to invalidate caches
+ */
+add_action( 'woocommerce_update_product_variation', 'wc_invalidate_variation_rest_cache', 10, 1 );
+add_action( 'woocommerce_new_product_variation', 'wc_invalidate_variation_rest_cache', 10, 1 );
+add_action( 'woocommerce_delete_product_variation', 'wc_invalidate_variation_rest_cache', 10, 1 );
+
+function wc_invalidate_variation_rest_cache( $variation_id ) {
+	$controller = new WC_REST_Product_Variations_Controller();
+	
+	// Invalidate cache for this variation
+	$controller->invalidate_entity_cache( $variation_id );
+	
+	// Also invalidate parent product
+	$variation = wc_get_product( $variation_id );
+	if ( $variation && $variation->get_parent_id() ) {
+		$product_controller = new WC_REST_Products_Controller();
+		$product_controller->invalidate_entity_cache( $variation->get_parent_id() );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
+++ b/plugins/woocommerce/src/Internal/Traits/RestApiCache.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * REST API Caching Trait
+ *
+ * Provides caching functionality for REST API controllers.
+ * Can be used by both WC_REST_Controller and RestApiControllerBase.
+ */
+
+namespace Automattic\WooCommerce\Internal\Traits;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Trait for adding caching capabilities to REST API controllers.
+ *
+ * Usage:
+ * 1. Add 'use RestApiCache;' to your controller class
+ * 2. Implement required methods
+ * 3. Call register_cache_hooks() in constructor or register() method
+ *
+ * @since   9.5.0
+ */
+trait RestApiCache {
+
+	/**
+	 * Register cache-related hooks.
+	 *
+	 * Call this from the controller's constructor or init method.
+	 */
+	protected function register_cache_hooks() {
+		add_filter( 'rest_pre_dispatch', array( $this, 'handle_rest_pre_dispatch' ), 10, 3 );
+		add_filter( 'rest_post_dispatch', array( $this, 'handle_rest_post_dispatch' ), 10, 3 );
+		add_filter( 'rest_send_nocache_headers', array( $this, 'handle_rest_send_nocache_headers' ), 10, 2 );
+	}
+
+	/**
+	 * Get the current request route.
+	 *
+	 * Helper method for controllers to avoid having to call $request->get_route() repeatedly.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return string Request route.
+	 */
+	protected function get_request_route( $request ) {
+		return $request->get_route();
+	}
+
+	/**
+	 * Get the matched route pattern for the current request.
+	 *
+	 * This returns the route pattern that was matched (e.g., '/wc/v3/products/(?P<id>[\d]+)')
+	 * rather than the actual route (e.g., '/wc/v3/products/123').
+	 * Useful for determining which endpoint was matched without parsing.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return string|null Matched route pattern or null if not available.
+	 */
+	protected function get_matched_route( $request ) {
+		$route = $request->get_route();
+		$routes = rest_get_server()->get_routes();
+		
+		foreach ( $routes as $pattern => $handlers ) {
+			if ( preg_match( '@^' . $pattern . '$@i', $route ) ) {
+				return $pattern;
+			}
+		}
+		
+		return null;
+	}
+
+	/**
+	 * Get cache key information for the request.
+	 *
+	 * Override this method in classes to enable caching.
+	 * Return null to skip caching for this request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|null Array with 'key' (string) and optional 'entity_id' (int), or null to skip caching.
+	 */
+	protected function get_cache_key_info( $request ) {
+		return null; // Default: no caching.
+	}
+
+	/**
+	 * Get filter names to include in cache hash.
+	 *
+	 * Override in classes to specify which hooks affect the response.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Array of filter names.
+	 */
+	protected function get_cache_hash_filters( $request ) {
+		return array();
+	}
+
+	/**
+	 * Check if response data is a collection.
+	 *
+	 * Override in classes if you need custom collection detection logic.
+	 *
+	 * @param array $data Response data.
+	 * @return bool True if data represents a collection, false for single item.
+	 */
+	protected function is_collection( $data ) {
+		// Collections are indexed arrays with numeric keys starting at 0.
+		// Single items are associative arrays with string keys.
+		return isset( $data[0] );
+	}
+
+	/**
+	 * Extract entity ID from a single entity array.
+	 *
+	 * Override in classes if your entities use a different ID field.
+	 *
+	 * @param array $entity Single entity data.
+	 * @return int|null Entity ID or null if not found.
+	 */
+	protected function extract_entity_id( $entity ) {
+		return $entity['id'] ?? null;
+	}
+
+	/**
+	 * Extract entity IDs from response data.
+	 *
+	 * Most classes won't need to override this - override extract_entity_id() instead.
+	 *
+	 * @param array $data Response data.
+	 * @return array Array of entity IDs.
+	 */
+	protected function extract_entity_ids( $data ) {
+		$ids = array();
+
+		if ( $this->is_collection( $data ) ) {
+			// Collection - extract IDs from each item.
+			foreach ( $data as $item ) {
+				$id = $this->extract_entity_id( $item );
+				if ( null !== $id ) {
+					$ids[] = $id;
+				}
+			}
+		} else {
+			// Single item.
+			$id = $this->extract_entity_id( $data );
+			if ( null !== $id ) {
+				$ids[] = $id;
+			}
+		}
+
+		return array_unique( array_filter( $ids ) );
+	}
+
+	/**
+	 * Remove non-deterministic fields from data for ETag generation.
+	 *
+	 * Override in classes to exclude fields that change on each request
+	 * (e.g., random recommendations, timestamps).
+	 *
+	 * @param array $data Response data.
+	 * @return array Cleaned data.
+	 */
+	protected function remove_non_deterministic_fields( $data ) {
+		return $data; // Default: no cleaning.
+	}
+
+	/**
+	 * Get cache TTL in seconds.
+	 *
+	 * Override in classes to customize cache duration.
+	 *
+	 * @return int Cache TTL in seconds.
+	 */
+	protected function get_cache_ttl() {
+		return 5 * MINUTE_IN_SECONDS;
+	}
+
+	/**
+	 * Generate cache hash based on request and hooks.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return string Cache hash.
+	 */
+	protected function generate_cache_hash( $request ) {
+		global $wp_filter;
+
+		$cache_hash_data = array();
+		$filter_names    = $this->get_cache_hash_filters( $request );
+
+		foreach ( $filter_names as $filter_name ) {
+			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
+				$cache_hash_data[ $filter_name ] = array();
+
+				foreach ( $wp_filter[ $filter_name ] as $priority => $callbacks ) {
+					$cache_hash_data[ $filter_name ][ $priority ] = array_values(
+						wp_list_pluck( $callbacks, 'function' )
+					);
+				}
+			}
+		}
+
+		/**
+		 * Filter cache hash data.
+		 *
+		 * @param array           $cache_hash_data Hash data.
+		 * @param WP_REST_Request $request         Request object.
+		 * @param object          $controller      Controller instance.
+		 */
+		$cache_hash_data = apply_filters(
+			'woocommerce_rest_api_cache_hash',
+			$cache_hash_data,
+			$request,
+			$this
+		);
+
+		return md5( wp_json_encode( $cache_hash_data ) );
+	}
+
+	/**
+	 * Register collection cache for entity (reverse index).
+	 *
+	 * @param int    $entity_id            Entity ID.
+	 * @param string $collection_cache_key Collection cache key.
+	 */
+	protected function register_collection_cache_for_entity( $entity_id, $collection_cache_key ) {
+		$index_key   = $this->get_entity_collection_index_key( $entity_id );
+		$collections = get_transient( $index_key );
+
+		if ( ! is_array( $collections ) ) {
+			$collections = array();
+		}
+
+		if ( ! in_array( $collection_cache_key, $collections, true ) ) {
+			$collections[] = $collection_cache_key;
+			// Use TTL + 1 minute buffer to ensure index outlives cache.
+			set_transient( $index_key, $collections, $this->get_cache_ttl() + MINUTE_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Get collection caches that include a specific entity.
+	 *
+	 * @param int $entity_id Entity ID.
+	 * @return array Array of collection cache keys.
+	 */
+	protected function get_collection_caches_for_entity( $entity_id ) {
+		$index_key   = $this->get_entity_collection_index_key( $entity_id );
+		$collections = get_transient( $index_key );
+
+		return is_array( $collections ) ? $collections : array();
+	}
+
+	/**
+	 * Get entity collection index key.
+	 *
+	 * Override in classes to customize the index key pattern.
+	 *
+	 * @param int $entity_id Entity ID.
+	 * @return string Index key.
+	 */
+	protected function get_entity_collection_index_key( $entity_id ) {
+		// Use a normalized rest base if available, otherwise fall back to simple key.
+		if ( method_exists( $this, 'get_normalized_rest_base' ) ) {
+			return 'wc_rest_' . $this->get_normalized_rest_base() . '_collections_' . $entity_id;
+		}
+
+		return 'wc_rest_entity_collections_' . $entity_id;
+	}
+
+	/**
+	 * Handle rest_pre_dispatch filter to check cache and return early if valid.
+	 *
+	 * @internal
+	 *
+	 * @param mixed           $result  Response to replace the requested version with.
+	 * @param WP_REST_Server  $server  Server instance.
+	 * @param WP_REST_Request $request Request used to generate the response.
+	 * @return mixed Response or original result.
+	 */
+	public function handle_rest_pre_dispatch( $result, $server, $request ) {
+		// Check for cache skip parameter first to minimize overhead.
+		if ( $request->get_param( '_skip_cache' ) === 'true' ) {
+			return null;
+		}
+
+		// Only handle GET requests for this controller's endpoints.
+		if ( $result !== null || $request->get_method() !== 'GET' ) {
+			return $result;
+		}
+
+		// If another controller already handled caching, skip.
+		if ( $request->get_param( '_cache_info' ) ) {
+			return $result;
+		}
+
+		// Get cache key info - returns null if route doesn't match this controller.
+		$cache_info = $this->get_cache_key_info( $request );
+		if ( ! $cache_info ) {
+			return null;
+		}
+
+		// Store cache info for post-dispatch to reuse (avoid calling get_cache_key_info twice).
+		$request->set_param( '_cache_info', $cache_info );
+		
+		// Store controller class to ensure the same controller handles both pre and post dispatch.
+		$request->set_param( '_caching_controller_class', get_class( $this ) );
+
+		// Try to get cached response.
+		$cached = get_transient( $cache_info['key'] );
+
+		// No cache or invalid cache structure - continue to normal processing.
+		if ( ! $cached || ! isset( $cached['hash'], $cached['etag'], $cached['data'], $cached['created_at'] ) ) {
+			return null;
+		}
+
+		// Check if cache has expired based on creation time.
+		$current_time    = time();
+		$expiration_time = $cached['created_at'] + $this->get_cache_ttl();
+		if ( $current_time >= $expiration_time ) {
+			// Cache expired - delete and continue to normal processing.
+			delete_transient( $cache_info['key'] );
+			return null;
+		}
+
+		// Calculate current hash to see if hooks have changed.
+		$current_hash = $this->generate_cache_hash( $request );
+
+		if ( $cached['hash'] !== $current_hash ) {
+			// Hooks have changed - invalidate cache.
+			delete_transient( $cache_info['key'] );
+			return null;
+		}
+
+		// Cache is valid - check ETag.
+		$request_etag = $request->get_header( 'if_none_match' );
+
+		// Determine cache visibility based on authentication.
+		$cache_visibility = is_user_logged_in() ? 'private' : 'public';
+
+		// Prepare cache headers (used for both 304 and 200 responses).
+		// Date header shows when the data was cached (important for max-age calculation).
+		$cache_headers = array(
+			'ETag'          => $cached['etag'],
+			'Cache-Control' => $cache_visibility . ', must-revalidate, max-age=' . $this->get_cache_ttl(),
+			'Date'          => gmdate( 'D, d M Y H:i:s', $cached['created_at'] ) . ' GMT',
+		);
+
+		if ( $request_etag === $cached['etag'] ) {
+			// Return 304 - no database queries!
+			$cache_headers['X-WC-Cache'] = 'HIT';
+			return new WP_REST_Response( null, 304, $cache_headers );
+		}
+
+		// Cache valid but ETag doesn't match - return cached data with full headers.
+		$cache_headers['X-WC-Cache'] = 'HIT';
+		return new WP_REST_Response( $cached['data'], 200, $cache_headers );
+	}
+
+	/**
+	 * Handle rest_send_nocache_headers filter to prevent WordPress from overriding our cache headers.
+	 *
+	 * @internal
+	 *
+	 * @param bool            $send_no_cache_headers Whether to send no-cache headers.
+	 * @param WP_REST_Request $request               Request object.
+	 * @return bool False if we're handling caching, original value otherwise.
+	 */
+	public function handle_rest_send_nocache_headers( $send_no_cache_headers, $request ) {
+		// If any controller is handling caching for this request, don't let WordPress send no-cache headers.
+		if ( $request->get_param( '_cache_info' ) ) {
+			return false;
+		}
+
+		return $send_no_cache_headers;
+	}
+
+	/**
+	 * Handle rest_post_dispatch filter to cache the response after all hooks have run.
+	 *
+	 * @internal
+	 *
+	 * @param WP_REST_Response $response Result to send to the client.
+	 * @param WP_REST_Server   $server   Server instance.
+	 * @param WP_REST_Request  $request  Request used to generate the response.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function handle_rest_post_dispatch( $response, $server, $request ) {
+		// Check for cache skip parameter first to minimize overhead.
+		if ( $request->get_param( '_skip_cache' ) === 'true' ) {
+			$response->header( 'X-WC-Cache', 'SKIP' );
+			return $response;
+		}
+
+		// Only handle GET requests that succeeded.
+		if ( $request->get_method() !== 'GET' || $response->get_status() !== 200 ) {
+			return $response;
+		}
+
+		// Get cache info from pre-dispatch (already computed there).
+		$cache_info = $request->get_param( '_cache_info' );
+		if ( ! $cache_info ) {
+			// Pre-dispatch didn't set cache info, so this request doesn't use caching.
+			return $response;
+		}
+
+		// Verify this is the same controller that handled pre-dispatch.
+		$caching_controller = $request->get_param( '_caching_controller_class' );
+		if ( $caching_controller !== get_class( $this ) ) {
+			return $response;
+		}
+
+		// If this was a cache hit from pre-dispatch, all headers are already set.
+		// Pre-dispatch sets: ETag, Cache-Control, Date, X-WC-Cache
+		$headers = $response->get_headers();
+		if ( isset( $headers['X-WC-Cache'] ) ) {
+			return $response; // Headers already complete, nothing to do.
+		}
+
+		$data = $response->get_data();
+
+		// Extract entity IDs from the response.
+		$entity_ids = $this->extract_entity_ids( $data );
+
+		// Remove non-deterministic fields for ETag generation.
+		$etag_data = $this->remove_non_deterministic_fields( $data );
+
+		// Generate ETag from the actual response content.
+		$etag = '"' . md5( wp_json_encode( $etag_data ) ) . '"';
+
+		// Determine cache visibility based on authentication.
+		$cache_visibility = is_user_logged_in() ? 'private' : 'public';
+
+		// Set cache headers.
+		$response->header( 'ETag', $etag );
+		$response->header( 'Cache-Control', $cache_visibility . ', must-revalidate, max-age=' . $this->get_cache_ttl() );
+		$response->header( 'X-WC-Cache', 'MISS' );
+
+		// Prepare cached data.
+		$cache_data = array(
+			'hash'       => $this->generate_cache_hash( $request ),
+			'etag'       => $etag,
+			'data'       => $data,
+			'entity_ids' => $entity_ids,
+			'created_at' => time(), // UTC timestamp for explicit expiration checking.
+		);
+
+		// Cache the response.
+		set_transient( $cache_info['key'], $cache_data, $this->get_cache_ttl() );
+
+		// Build reverse index for cache invalidation.
+		if ( $this->is_collection( $data ) ) {
+			// For collections, track all entity IDs in the response.
+			foreach ( $entity_ids as $entity_id ) {
+				$this->register_collection_cache_for_entity( $entity_id, $cache_info['key'] );
+			}
+		} elseif ( isset( $cache_info['entity_id'] ) ) {
+			// For single entities, also use reverse index to handle query param variations.
+			$this->register_collection_cache_for_entity( $cache_info['entity_id'], $cache_info['key'] );
+		}
+
+		// Remove cache info and controller class so other controllers know this request was handled.
+		$request->set_param( '_cache_info', null );
+		$request->set_param( '_caching_controller_class', null );
+
+		return $response;
+	}
+
+	/**
+	 * Invalidate cache for an entity.
+	 *
+	 * Call this method when an entity changes to clear its caches.
+	 * This will delete all cache entries related to the entity (single entity with various query params + collections).
+	 *
+	 * @param int $entity_id Entity ID.
+	 */
+	public function invalidate_entity_cache( $entity_id ) {
+		// Get all cache keys for this entity (includes single entity with various query params + collections).
+		$cache_keys = $this->get_collection_caches_for_entity( $entity_id );
+		
+		foreach ( $cache_keys as $cache_key ) {
+			delete_transient( $cache_key );
+		}
+
+		// Clean up the reverse index.
+		delete_transient( $this->get_entity_collection_index_key( $entity_id ) );
+
+		/**
+		 * Fires after cache invalidation for an entity.
+		 *
+		 * @param int    $entity_id  Entity ID.
+		 * @param object $controller Controller instance.
+		 */
+		do_action( 'woocommerce_rest_api_cache_invalidated', $entity_id, $this );
+	}
+}


### PR DESCRIPTION
Remove redundant `is_collection` key from REST API cache info.

The `is_collection` key in `get_cache_key_info()` was redundant as the `RestApiCache` trait can now determine if a response is a collection by inspecting the actual response data via the `is_collection()` method. This simplifies controller configuration and improves accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-93e7b8e8-8b35-43ba-9342-c54beff1aee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93e7b8e8-8b35-43ba-9342-c54beff1aee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

