### PR TITLE
[Backport to release/10.5] Bump Action Scheduler version to 3.9.0

### DIFF
--- a/plugins/woocommerce/changelog/update-action-scheduler-via-automation
+++ b/plugins/woocommerce/changelog/update-action-scheduler-via-automation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the Action Scheduler package to version 3.9.0.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -53,7 +53,7 @@
 		"composer/installers": "^1.9",
 		"maxmind-db/reader": "^1.11",
 		"opis/json-schema": "*",
-		"woocommerce/action-scheduler": "3.9.3",
+		"woocommerce/action-scheduler": "3.9.0",
 		"woocommerce/blueprint": "*",
 		"woocommerce/email-editor": "*",
 		"wordpress/abilities-api": "^0.4.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
+<<<<<<< HEAD
     "content-hash": "d53a02736b9464bf4de8108d46e2c77d",
+=======
+    "content-hash": "4be8b6929b256a6ac012ddd2505c6bd5",
+>>>>>>> 07718f9726 (Update Action Scheduler to '3.9.0'. (#137))
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1070,23 +1074,23 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.9.3",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c"
+                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/c58cdbab17651303d406cd3b22cf9d75c71c986c",
-                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/90b98e6fe97d455679b1d288f050cad8f6f79771",
+                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5",
+                "phpunit/phpunit": "^7.5",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
                 "wp-cli/wp-cli": "~2.5.0",
                 "yoast/phpunit-polyfills": "^2.0"
@@ -1107,9 +1111,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.3"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.0"
             },
-            "time": "2025-07-15T09:32:30+00:00"
+            "time": "2024-11-15T00:11:39+00:00"
         },
         {
             "name": "woocommerce/blueprint",


### PR DESCRIPTION
This PR is a cherry-pick of #137 to `release/10.5`.

⚠️ **WARNING**: This cherry-pick contained conflicts that have not been resolved. Please review the changes carefully before merging!

## Original PR Description

This PR updates the Action Scheduler package requirement for WooCommerce core.